### PR TITLE
Updating BPI-2101 enums

### DIFF
--- a/hpxml_version_translator/converter.py
+++ b/hpxml_version_translator/converter.py
@@ -247,6 +247,8 @@ def convert_hpxml2_to_3(hpxml2_file, hpxml3_file):
 
     # Green Building Verification
     # https://github.com/hpxmlwg/hpxml/pull/66
+    # This next one is covered here because the BPI-2101 verification didn't exist in v2, so no need to translate it
+    # https://github.com/hpxmlwg/hpxml/pull/210
 
     energy_score_els = root.xpath(
         'h:Building/h:BuildingDetails/h:BuildingSummary/h:BuildingConstruction/h:EnergyScore', **xpkw
@@ -1069,9 +1071,6 @@ def convert_hpxml2_to_3(hpxml2_file, hpxml3_file):
 
     # TODO: Window sub-components
     # https://github.com/hpxmlwg/hpxml/pull/202
-
-    # TODO: updating BPI-2101 enums in GreenBuildingVerification/Type
-    # https://github.com/hpxmlwg/hpxml/pull/210
 
     # Write out new file
     hpxml3_doc.write(pathobj_to_str(hpxml3_file), pretty_print=True, encoding='utf-8')

--- a/test/hpxml_files/green_building_verification.xml
+++ b/test/hpxml_files/green_building_verification.xml
@@ -62,7 +62,7 @@
             <CertifyingOrganization>USGBC</CertifyingOrganization>
             <CertifyingOrganizationURL>http://usgbc.org</CertifyingOrganizationURL>
             <YearCertified>2019</YearCertified>
-            <ProgramCertificate>LEED Gold</ProgramCertificate>            
+            <ProgramCertificate>LEED Gold</ProgramCertificate>
         </ProjectDetails>
     </Project>
 </HPXML>


### PR DESCRIPTION
Fixes #12 

The changes mentioned in #12 and https://github.com/hpxmlwg/hpxml/pull/210 were to something that was [added for v3 in a previous PR](https://github.com/hpxmlwg/hpxml/pull/210). Since that didn't exist in v2, there's nothing to translate. I moved the comment and link up by the other green building verification stuff.