### PR TITLE
Punting on bpi2400 translation from v1.1.1 to v2.x

### DIFF
--- a/hpxml_version_translator/converter.py
+++ b/hpxml_version_translator/converter.py
@@ -219,6 +219,20 @@ def convert_hpxml1_to_2(
             )
         batch_heater.remove(batch_heater.CollectorLoopType)
 
+    # Throw a warning if there are BPI2400 elements and move it into an extension
+    bpi2400_els = root.xpath("//h:BPI2400Inputs", **xpkw)
+    if bpi2400_els:
+        warnings.warn(
+            "BPI2400Inputs in v1.1.1 are ambiguous and aren't translated into their "
+            "corresponding elements in v2.x. They have been moved to an extension instead."
+        )
+    for el in bpi2400_els:
+        parent_el = el.getparent()
+        if not hasattr(parent_el, "extension"):
+            parent_el.append(E.extension())
+        parent_el.extension.append(deepcopy(el))
+        parent_el.remove(el)
+
     # Write out new file
     hpxml2_doc.write(pathobj_to_str(hpxml2_file), pretty_print=True, encoding="utf-8")
     hpxml2_schema.assertValid(hpxml2_doc)

--- a/test/hpxml_v1_files/bpi2400.xml
+++ b/test/hpxml_v1_files/bpi2400.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<HPXML xmlns="http://hpxml.org/hpxml/2011/1" schemaVersion="1.1.1">
+    <XMLTransactionHeaderInformation>
+        <XMLType></XMLType>
+        <XMLGeneratedBy></XMLGeneratedBy>
+        <CreatedDateAndTime>2021-04-05T13:01:49.803920</CreatedDateAndTime>
+        <Transaction>create</Transaction>
+    </XMLTransactionHeaderInformation>
+    <SoftwareInfo/>
+    <Consumption>
+        <BuildingID/>
+        <CustomerID/>
+        <BPI2400Inputs>
+            <BaseloadBillingPeriodStartDate>2021-12-01</BaseloadBillingPeriodStartDate>
+            <BaseloadBillingPeriodEndDate>2021-12-31</BaseloadBillingPeriodEndDate>
+            <BaseloadHeatingFuelType>electricity</BaseloadHeatingFuelType>
+        </BPI2400Inputs>
+    </Consumption>
+</HPXML>

--- a/test/test_converter_v1.py
+++ b/test/test_converter_v1.py
@@ -66,3 +66,11 @@ def test_solar_thermal():
     sts2 = root.Building.BuildingDetails.Systems.SolarThermal.SolarThermalSystem[1]
     assert not hasattr(sts2, "CollectorLoopType")
     assert sts2.CollectorType == "single glazing black"
+
+
+def test_bpi2400():
+    with pytest.warns(UserWarning, match=r"BPI2400Inputs .+ are ambiguous"):
+        root = convert_hpxml_and_parse(hpxml_dir / "bpi2400.xml")
+
+    assert not hasattr(root.Consumption, "BPI2400Inputs")
+    assert hasattr(root.Consumption.extension, "BPI2400Inputs")


### PR DESCRIPTION
Sort of fixes #44.

The BPI-2400 inputs in v1.1.1 were kind of unusable. It's a regression model of utility bills. They weren't connected to one particular fuel type. There was also a lot of missing inputs. Frankly, I don't think anybody was using it in v1.x. When people started trying to use it, it became apparent that it wouldn't work so we made a lot of changes for 2.x to make that happen. 

Rather than try to apply a lot of guesswork to make the jump from 1.x to 2.x for this element, I opted to just copy the original into an extension and remove it from it's original location and throw a warning to let the user know what's going on.

If someone really needs this later, they can let us know and we can work with them to figure it out, but I doubt will be necessary.